### PR TITLE
Delete .env

### DIFF
--- a/.env
+++ b/.env
@@ -1,2 +1,0 @@
-VITE_POSYAYEE_API_KEY=http://localhost:8080
-VITE_IMG_KEY=http://localhost:8080/uploads/


### PR DESCRIPTION
Delete env because it will remove the actual API KEY that is not localhost.